### PR TITLE
feat: add oci oke creation feature

### DIFF
--- a/terraform/modules/oci/oke/main.tf
+++ b/terraform/modules/oci/oke/main.tf
@@ -1,0 +1,53 @@
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}
+
+provider "oci" {
+  alias = "oke"
+}
+
+resource "oci_identity_compartment" "example" {
+  compartment_id = var.compartment_id
+  description    = "example"
+  name           = "example"
+}
+
+resource "oci_containerengine_cluster" "example" {
+  provider           = oci.oke
+  compartment_id     = oci_identity_compartment.example.id
+  name               = "example"
+  kubernetes_version = "v1.27.2"
+  vcn_id             = module.vcn.vcn_id
+}
+
+data "oci_identity_availability_domains" "available_availability_domains" {
+  compartment_id = var.compartment_id
+}
+
+resource "oci_containerengine_node_pool" "default" {
+  name           = "default"
+  compartment_id = var.compartment_id
+  cluster_id     = oci_containerengine_cluster.example.id
+  node_shape     = "VM.Standard.E3.Flex"
+  node_shape_config {
+    memory_in_gbs = 32
+    ocpus         = 2
+  }
+  node_source_details {
+    image_id    = var.image_id
+    source_type = "image"
+  }
+  node_config_details {
+    size = 3
+    placement_configs {
+      availability_domain = data.oci_identity_availability_domains.available_availability_domains.availability_domains[0].name
+      subnet_id           = oci_core_subnet.vcn-private-subnet.id
+    }
+  }
+  kubernetes_version = "v1.27.2"
+}
+

--- a/terraform/modules/oci/oke/main.tf
+++ b/terraform/modules/oci/oke/main.tf
@@ -10,16 +10,16 @@ provider "oci" {
   alias = "oke"
 }
 
-resource "oci_identity_compartment" "example" {
+resource "oci_identity_compartment" "obsrv_env" {
   compartment_id = var.compartment_id
-  description    = "example"
-  name           = "example"
+  description    = "obsrv_env"
+  name           = "obsrv_env"
 }
 
-resource "oci_containerengine_cluster" "example" {
+resource "oci_containerengine_cluster" "obsrv_env" {
   provider           = oci.oke
-  compartment_id     = oci_identity_compartment.example.id
-  name               = "example"
+  compartment_id     = oci_identity_compartment.obsrv_env.id
+  name               = "obsrv_env"
   kubernetes_version = "v1.27.2"
   vcn_id             = module.vcn.vcn_id
 }
@@ -28,10 +28,10 @@ data "oci_identity_availability_domains" "available_availability_domains" {
   compartment_id = var.compartment_id
 }
 
-resource "oci_containerengine_node_pool" "default" {
-  name           = "default"
+resource "oci_containerengine_node_pool" "obsrv_np" {
+  name           = "obsrv_np"
   compartment_id = var.compartment_id
-  cluster_id     = oci_containerengine_cluster.example.id
+  cluster_id     = oci_containerengine_cluster.obsrv_env.id
   node_shape     = "VM.Standard.E3.Flex"
   node_shape_config {
     memory_in_gbs = 32

--- a/terraform/modules/oci/oke/outputs.tf
+++ b/terraform/modules/oci/oke/outputs.tf
@@ -1,0 +1,91 @@
+output "vcn_id" {
+  description = "OCID of the VCN that is created"
+  value       = module.vcn.vcn_id
+}
+output "id-for-route-table-that-includes-the-internet-gateway" {
+  description = "OCID of the internet-route table. This route table has an internet gateway to be used for public subnets"
+  value       = module.vcn.ig_route_id
+}
+output "nat-gateway-id" {
+  description = "OCID for NAT gateway"
+  value       = module.vcn.nat_gateway_id
+}
+output "id-for-for-route-table-that-includes-the-nat-gateway" {
+  description = "OCID of the nat-route table - This route table has a nat gateway to be used for private subnets. This route table also has a service gateway."
+  value       = module.vcn.nat_route_id
+}
+
+# Outputs for private security list
+
+output "private-security-list-name" {
+  value = oci_core_security_list.private-security-list.display_name
+}
+output "private-security-list-OCID" {
+  value = oci_core_security_list.private-security-list.id
+}
+
+
+# Outputs for public security list
+
+output "public-security-list-name" {
+  value = oci_core_security_list.public-security-list.display_name
+}
+output "public-security-list-OCID" {
+  value = oci_core_security_list.public-security-list.id
+}
+
+# Outputs for private subnet
+
+output "private-subnet-name" {
+  value = oci_core_subnet.vcn-private-subnet.display_name
+}
+output "private-subnet-OCID" {
+  value = oci_core_subnet.vcn-private-subnet.id
+}
+
+
+# Outputs for public subnet
+
+output "public-subnet-name" {
+  value = oci_core_subnet.vcn-public-subnet.display_name
+}
+output "public-subnet-OCID" {
+  value = oci_core_subnet.vcn-public-subnet.id
+}
+
+# Outputs for k8s cluster
+
+output "cluster-name" {
+  value = oci_containerengine_cluster.example.name
+}
+output "cluster-OCID" {
+  value = oci_containerengine_cluster.example.id
+}
+output "cluster-kubernetes-version" {
+  value = oci_containerengine_cluster.example.kubernetes_version
+}
+output "cluster-state" {
+  value = oci_containerengine_cluster.example.state
+}
+
+# Outputs for k8s node pool
+
+output "node-pool-name" {
+  value = oci_containerengine_node_pool.default.name
+}
+output "node-pool-OCID" {
+  value = oci_containerengine_node_pool.default.id
+}
+output "node-pool-kubernetes-version" {
+  value = oci_containerengine_node_pool.default.kubernetes_version
+}
+output "node-size" {
+  value = oci_containerengine_node_pool.default.node_config_details[0].size
+}
+output "node-shape" {
+  value = oci_containerengine_node_pool.default.node_shape
+}
+
+output "available_availability_domains" {
+  value = data.oci_identity_availability_domains.available_availability_domains.availability_domains
+}

--- a/terraform/modules/oci/oke/variables.tf
+++ b/terraform/modules/oci/oke/variables.tf
@@ -1,0 +1,11 @@
+variable "compartment_id" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "private_key_path" {}
+variable "fingerprint" {}
+variable "region" {}
+variable "image_id" {}
+variable "source_id" {}
+variable "subnet_id" {}
+variable "ssh_authorized_keys" {}
+variable "ssh_private_key" {}

--- a/terraform/modules/oci/oke/variables.tf
+++ b/terraform/modules/oci/oke/variables.tf
@@ -1,11 +1,24 @@
-variable "compartment_id" {}
-variable "tenancy_ocid" {}
-variable "user_ocid" {}
-variable "private_key_path" {}
-variable "fingerprint" {}
-variable "region" {}
-variable "image_id" {}
-variable "source_id" {}
-variable "subnet_id" {}
-variable "ssh_authorized_keys" {}
-variable "ssh_private_key" {}
+variable "compartment_id" {
+    description = "Compartment created on OCI same as that of IAM in AWS"
+}
+variable "tenancy_ocid" {
+    description = "Oracle-assigned unique ID"
+}
+variable "user_ocid" {
+    description = " the OCID of the user for whom the key pair is being added"
+}
+variable "private_key_path" {
+    description = "Path to private key to access OCI in your local system"
+}
+variable "fingerprint" {
+    description = "The fingerprint of the key"
+}
+variable "region" {
+    description = "Region in which you want you infrastruture to be created"
+}
+variable "image_id" {
+    description = "Image ID of the Linux distribution you want to use for OKE creation"
+}
+variable "subnet_id" {
+    description = "Subnet to be used in VCN creation"
+}

--- a/terraform/modules/oci/subnets/outputs.tf
+++ b/terraform/modules/oci/subnets/outputs.tf
@@ -1,0 +1,91 @@
+output "vcn_id" {
+  description = "OCID of the VCN that is created"
+  value       = module.vcn.vcn_id
+}
+output "id-for-route-table-that-includes-the-internet-gateway" {
+  description = "OCID of the internet-route table. This route table has an internet gateway to be used for public subnets"
+  value       = module.vcn.ig_route_id
+}
+output "nat-gateway-id" {
+  description = "OCID for NAT gateway"
+  value       = module.vcn.nat_gateway_id
+}
+output "id-for-for-route-table-that-includes-the-nat-gateway" {
+  description = "OCID of the nat-route table - This route table has a nat gateway to be used for private subnets. This route table also has a service gateway."
+  value       = module.vcn.nat_route_id
+}
+
+# Outputs for private security list
+
+output "private-security-list-name" {
+  value = oci_core_security_list.private-security-list.display_name
+}
+output "private-security-list-OCID" {
+  value = oci_core_security_list.private-security-list.id
+}
+
+
+# Outputs for public security list
+
+output "public-security-list-name" {
+  value = oci_core_security_list.public-security-list.display_name
+}
+output "public-security-list-OCID" {
+  value = oci_core_security_list.public-security-list.id
+}
+
+# Outputs for private subnet
+
+output "private-subnet-name" {
+  value = oci_core_subnet.vcn-private-subnet.display_name
+}
+output "private-subnet-OCID" {
+  value = oci_core_subnet.vcn-private-subnet.id
+}
+
+
+# Outputs for public subnet
+
+output "public-subnet-name" {
+  value = oci_core_subnet.vcn-public-subnet.display_name
+}
+output "public-subnet-OCID" {
+  value = oci_core_subnet.vcn-public-subnet.id
+}
+
+# Outputs for k8s cluster
+
+output "cluster-name" {
+  value = oci_containerengine_cluster.example.name
+}
+output "cluster-OCID" {
+  value = oci_containerengine_cluster.example.id
+}
+output "cluster-kubernetes-version" {
+  value = oci_containerengine_cluster.example.kubernetes_version
+}
+output "cluster-state" {
+  value = oci_containerengine_cluster.example.state
+}
+
+# Outputs for k8s node pool
+
+output "node-pool-name" {
+  value = oci_containerengine_node_pool.default.name
+}
+output "node-pool-OCID" {
+  value = oci_containerengine_node_pool.default.id
+}
+output "node-pool-kubernetes-version" {
+  value = oci_containerengine_node_pool.default.kubernetes_version
+}
+output "node-size" {
+  value = oci_containerengine_node_pool.default.node_config_details[0].size
+}
+output "node-shape" {
+  value = oci_containerengine_node_pool.default.node_shape
+}
+
+output "available_availability_domains" {
+  value = data.oci_identity_availability_domains.available_availability_domains.availability_domains
+}

--- a/terraform/modules/oci/subnets/private-security-list.tf
+++ b/terraform/modules/oci/subnets/private-security-list.tf
@@ -1,0 +1,48 @@
+# Source from https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_security_list
+
+resource "oci_core_security_list" "private-security-list" {
+  compartment_id = var.compartment_id
+  vcn_id         = module.vcn.vcn_id
+  display_name = "security-list-for-private-subnet"
+  egress_security_rules {
+    stateless        = false
+    destination      = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    protocol         = "all"
+  }
+
+
+  ingress_security_rules {
+    stateless   = false
+    source      = "10.0.0.0/16"
+    source_type = "CIDR_BLOCK"
+    protocol = "6"
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+  ingress_security_rules {
+    stateless   = false
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    protocol = "1"
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
+  ingress_security_rules {
+    stateless   = false
+    source      = "10.0.0.0/16"
+    source_type = "CIDR_BLOCK"
+    protocol = "1"
+    icmp_options {
+      type = 3
+    }
+  }
+
+
+}
+

--- a/terraform/modules/oci/subnets/private-subnet.tf
+++ b/terraform/modules/oci/subnets/private-subnet.tf
@@ -1,0 +1,12 @@
+# Source from https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_subnet
+
+resource "oci_core_subnet" "vcn-private-subnet" {
+
+  # Required
+  compartment_id = var.compartment_id
+  vcn_id         = module.vcn.vcn_id
+  cidr_block     = "10.0.1.0/24"
+  route_table_id    = module.vcn.nat_route_id
+  security_list_ids = [oci_core_security_list.private-security-list.id]
+  display_name      = "private-subnet"
+}

--- a/terraform/modules/oci/subnets/public-security-list.tf
+++ b/terraform/modules/oci/subnets/public-security-list.tf
@@ -1,0 +1,44 @@
+# Source from https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_security_list
+
+resource "oci_core_security_list" "public-security-list" {
+  compartment_id = var.compartment_id
+  vcn_id         = module.vcn.vcn_id
+  display_name = "security-list-for-public-subnet"
+  egress_security_rules {
+    stateless        = false
+    destination      = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    protocol         = "all"
+  }
+  ingress_security_rules {
+    stateless   = false
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    protocol = "6"
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+  ingress_security_rules {
+    stateless   = false
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+    protocol = "1"
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
+  ingress_security_rules {
+    stateless   = false
+    source      = "10.0.0.0/16"
+    source_type = "CIDR_BLOCK"
+    protocol = "1"
+    icmp_options {
+      type = 3
+    }
+  }
+}
+

--- a/terraform/modules/oci/subnets/public-subnet.tf
+++ b/terraform/modules/oci/subnets/public-subnet.tf
@@ -1,0 +1,10 @@
+# Source from https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_subnet
+
+resource "oci_core_subnet" "vcn-public-subnet" {
+  compartment_id = var.compartment_id
+  vcn_id         = module.vcn.vcn_id
+  cidr_block     = "10.0.0.0/24"
+  route_table_id    = module.vcn.ig_route_id
+  security_list_ids = [oci_core_security_list.public-security-list.id]
+  display_name      = "public-subnet"
+}

--- a/terraform/modules/oci/subnets/variables.tf
+++ b/terraform/modules/oci/subnets/variables.tf
@@ -1,0 +1,11 @@
+variable "compartment_id" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "private_key_path" {}
+variable "fingerprint" {}
+variable "region" {}
+variable "image_id" {}
+variable "source_id" {}
+variable "subnet_id" {}
+variable "ssh_authorized_keys" {}
+variable "ssh_private_key" {}

--- a/terraform/modules/oci/subnets/variables.tf
+++ b/terraform/modules/oci/subnets/variables.tf
@@ -1,11 +1,3 @@
-variable "compartment_id" {}
-variable "tenancy_ocid" {}
-variable "user_ocid" {}
-variable "private_key_path" {}
-variable "fingerprint" {}
-variable "region" {}
-variable "image_id" {}
-variable "source_id" {}
-variable "subnet_id" {}
-variable "ssh_authorized_keys" {}
-variable "ssh_private_key" {}
+variable "compartment_id" {
+    description = "Compartment created on OCI same as that of IAM in AWS"
+}

--- a/terraform/modules/oci/vcn/main.tf
+++ b/terraform/modules/oci/vcn/main.tf
@@ -1,0 +1,23 @@
+# Source from https://registry.terraform.io/modules/oracle-terraform-modules/vcn/oci/
+module "vcn" {
+  source  = "oracle-terraform-modules/vcn/oci"
+  version = "3.1.0"
+
+
+  # Required Inputs
+  compartment_id = var.compartment_id
+  region         = var.region
+
+  internet_gateway_route_rules = null
+  local_peering_gateways       = null
+  nat_gateway_route_rules      = null
+
+  # Optional Inputs
+  vcn_name      = "example"
+  vcn_dns_label = "vcnmodule"
+  vcn_cidrs     = ["10.0.0.0/16"]
+
+  create_internet_gateway = true
+  create_nat_gateway      = true
+  create_service_gateway  = true
+}

--- a/terraform/modules/oci/vcn/outputs.tf
+++ b/terraform/modules/oci/vcn/outputs.tf
@@ -1,0 +1,91 @@
+output "vcn_id" {
+  description = "OCID of the VCN that is created"
+  value       = module.vcn.vcn_id
+}
+output "id-for-route-table-that-includes-the-internet-gateway" {
+  description = "OCID of the internet-route table. This route table has an internet gateway to be used for public subnets"
+  value       = module.vcn.ig_route_id
+}
+output "nat-gateway-id" {
+  description = "OCID for NAT gateway"
+  value       = module.vcn.nat_gateway_id
+}
+output "id-for-for-route-table-that-includes-the-nat-gateway" {
+  description = "OCID of the nat-route table - This route table has a nat gateway to be used for private subnets. This route table also has a service gateway."
+  value       = module.vcn.nat_route_id
+}
+
+# Outputs for private security list
+
+output "private-security-list-name" {
+  value = oci_core_security_list.private-security-list.display_name
+}
+output "private-security-list-OCID" {
+  value = oci_core_security_list.private-security-list.id
+}
+
+
+# Outputs for public security list
+
+output "public-security-list-name" {
+  value = oci_core_security_list.public-security-list.display_name
+}
+output "public-security-list-OCID" {
+  value = oci_core_security_list.public-security-list.id
+}
+
+# Outputs for private subnet
+
+output "private-subnet-name" {
+  value = oci_core_subnet.vcn-private-subnet.display_name
+}
+output "private-subnet-OCID" {
+  value = oci_core_subnet.vcn-private-subnet.id
+}
+
+
+# Outputs for public subnet
+
+output "public-subnet-name" {
+  value = oci_core_subnet.vcn-public-subnet.display_name
+}
+output "public-subnet-OCID" {
+  value = oci_core_subnet.vcn-public-subnet.id
+}
+
+# Outputs for k8s cluster
+
+output "cluster-name" {
+  value = oci_containerengine_cluster.example.name
+}
+output "cluster-OCID" {
+  value = oci_containerengine_cluster.example.id
+}
+output "cluster-kubernetes-version" {
+  value = oci_containerengine_cluster.example.kubernetes_version
+}
+output "cluster-state" {
+  value = oci_containerengine_cluster.example.state
+}
+
+# Outputs for k8s node pool
+
+output "node-pool-name" {
+  value = oci_containerengine_node_pool.default.name
+}
+output "node-pool-OCID" {
+  value = oci_containerengine_node_pool.default.id
+}
+output "node-pool-kubernetes-version" {
+  value = oci_containerengine_node_pool.default.kubernetes_version
+}
+output "node-size" {
+  value = oci_containerengine_node_pool.default.node_config_details[0].size
+}
+output "node-shape" {
+  value = oci_containerengine_node_pool.default.node_shape
+}
+
+output "available_availability_domains" {
+  value = data.oci_identity_availability_domains.available_availability_domains.availability_domains
+}

--- a/terraform/modules/oci/vcn/variables.tf
+++ b/terraform/modules/oci/vcn/variables.tf
@@ -1,11 +1,6 @@
-variable "compartment_id" {}
-variable "tenancy_ocid" {}
-variable "user_ocid" {}
-variable "private_key_path" {}
-variable "fingerprint" {}
-variable "region" {}
-variable "image_id" {}
-variable "source_id" {}
-variable "subnet_id" {}
-variable "ssh_authorized_keys" {}
-variable "ssh_private_key" {}
+variable "compartment_id" {
+    description = "Compartment created on OCI same as that of IAM in AWS"
+}
+variable "region" {
+    description = "Region in which you want you infrastruture to be created"
+}

--- a/terraform/modules/oci/vcn/variables.tf
+++ b/terraform/modules/oci/vcn/variables.tf
@@ -1,0 +1,11 @@
+variable "compartment_id" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "private_key_path" {}
+variable "fingerprint" {}
+variable "region" {}
+variable "image_id" {}
+variable "source_id" {}
+variable "subnet_id" {}
+variable "ssh_authorized_keys" {}
+variable "ssh_private_key" {}

--- a/terraform/oci/main.tf
+++ b/terraform/oci/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}
+
+# provider "helm" {
+#   kubernetes {
+#     
+#   }
+# }
+
+# provider "helm" {
+#     config_path = "~$HOME/.kube/config"
+#     alias  = "helm"
+#     kubernetes {
+#         host                   = module.oke.kubernetes_endpoint
+#         cluster_ca_certificate = module.oke.kubernetes_ca_cert
+#         exec {
+#             api_version = "client.authentication.k8s.io/v1beta1"
+#             command     = "oci"
+#             args        = ["k8s", "get-token", "--cluster-id", "${module.oke.cluster_id}"]
+#         }
+#     }
+# }
+
+   provider "helm" {  
+       kubernetes {  
+           config_path = "${path.root}/generated/kubeconfig"  
+       }  
+   }
+
+module "oke" {
+    source = "../modules/oci"
+    image_id = var.image_id
+    tenancy_ocid = var.tenancy_ocid
+    user_ocid = var.user_ocid
+    fingerprint = var.fingerprint
+    source_id = var.source_id
+    ssh_authorized_keys = var.ssh_authorized_keys
+    ssh_private_key = var.ssh_private_key
+    compartment_id = var.compartment_id
+    private_key_path = var.private_key_path
+    subnet_id = var.subnet_id
+    region = var.region
+}
+

--- a/terraform/oci/variables.tf
+++ b/terraform/oci/variables.tf
@@ -1,0 +1,24 @@
+variable "compartment_id" {}
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "private_key_path" {}
+variable "fingerprint" {}
+variable "region" {}
+variable "image_id" {}
+variable "source_id" {}
+variable "subnet_id" {}
+variable "ssh_authorized_keys" {}
+variable "ssh_private_key" {}
+
+variable "env" {
+  type        = string
+  description = "Environment name. All resources will be prefixed with this value."
+  default     = "dev"
+}
+
+variable "building_block" {
+  type        = string
+  description = "Building block name. All resources will be prefixed with this value."
+  default     = "obsrv"
+}
+

--- a/terraform/oci/variables.tf
+++ b/terraform/oci/variables.tf
@@ -1,21 +1,41 @@
-variable "compartment_id" {}
-variable "tenancy_ocid" {}
-variable "user_ocid" {}
-variable "private_key_path" {}
-variable "fingerprint" {}
-variable "region" {}
-variable "image_id" {}
-variable "source_id" {}
-variable "subnet_id" {}
-variable "ssh_authorized_keys" {}
-variable "ssh_private_key" {}
-
+variable "compartment_id" {
+  description = "Compartment created on OCI same as that of IAM in AWS"
+}
+variable "tenancy_ocid" {
+  description = "Oracle-assigned unique ID"
+}
+variable "user_ocid" {
+  description = " the OCID of the user for whom the key pair is being added"
+}
+variable "private_key_path" {
+  description = "Path to private key to access OCI in your local system"
+}
+variable "fingerprint" {
+  description = "The fingerprint of the key"
+}
+variable "region" {
+  description = "Region in which you want you infrastruture to be created"
+}
+variable "image_id" {
+  description = "Image ID of the Linux distribution you want to use for OKE creation"
+}
+variable "source_id" {
+  description = "Source id of the type of Linux used"
+}
+variable "subnet_id" {
+  description = "Subnet to be used in VCN creation"
+}
+variable "ssh_authorized_keys" {
+  description = "Path to the SSH public key on your environment"
+}
+variable "ssh_private_key" {
+  description = "Path to the SSH private key on your environment"
+}
 variable "env" {
   type        = string
   description = "Environment name. All resources will be prefixed with this value."
   default     = "dev"
 }
-
 variable "building_block" {
   type        = string
   description = "Building block name. All resources will be prefixed with this value."


### PR DESCRIPTION
This PR contains the code for OKE creation on OCI, there are a few exports that need to be made in order for this to work locally or on the cloud.

In `terraform/modules/oci` directory all the code for the creation of the cluster can be found. 

In `terraform/oci` directory all the code from the above directory is called in order to create an OKE Cluster.

In order to execute the code on OCI, clone this repo and move to the `terraform/oci` directory.
Export all the below-mentioned credentials using the given template:
**template - export TF_VAR_compartment_id = <id-value>**

- Compartment Id
- Region
- Tenancy Id
- User Id
- Private Key Path
- Fingerprint
- Subnet Id
- Image Id
- Source Id
- SSH Authorized Keys
- SSH Private Key

After exporting run the following commands:
- terraform init(To install all the necessary providers).
- terraform validate(To check the validation of all terraform files).
- terraform plan(To check a pre-test).
- terraform apply(To create the instance).

This PR will create an OKE cluster with 3 nodes with 32 GBs each with Kubernetes Version 1.27.2. All the details regarding the cluster details can be found in `terraform/modules/oci/oke/main.tf`.

Further changes to be made:
- Change the StorageClass Type of PVCs in helm charts to support OCI.
- Make the helm provider access the Kubernetes Cluster created using Terraform.

cc - @manjudr 